### PR TITLE
Add license and required_ruby_version attributes

### DIFF
--- a/aws_lambda_ric.gemspec
+++ b/aws_lambda_ric.gemspec
@@ -7,16 +7,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require './lib/aws_lambda_ric/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'aws_lambda_ric'
-  spec.version       = AwsLambdaRuntimeInterfaceClient::VERSION
-  spec.authors       = ['AWS Lambda']
+  spec.name                  = 'aws_lambda_ric'
+  spec.version               = AwsLambdaRuntimeInterfaceClient::VERSION
+  spec.authors               = ['AWS Lambda']
 
-  spec.summary       = 'AWS Lambda Runtime Interface Client for Ruby'
-  spec.description   = 'The AWS Lambda Ruby Runtime Interface Client implements the Lambda programming model for Ruby.'
-  spec.homepage      = 'https://github.com/aws/aws-lambda-ruby-runtime-interface-client'
+  spec.summary               = 'AWS Lambda Runtime Interface Client for Ruby'
+  spec.description           = 'The AWS Lambda Ruby Runtime Interface Client implements the Lambda programming model for Ruby.'
+  spec.homepage              = 'https://github.com/aws/aws-lambda-ruby-runtime-interface-client'
+
+  spec.license               = 'Apache-2.0'
+  spec.required_ruby_version = '>= 2.5'
 
   # Specify which files should be added to the gem when it is released.
-  spec.files         = %w[
+  spec.files                 = %w[
     LICENSE
     README.md
     Gemfile
@@ -26,10 +29,10 @@ Gem::Specification.new do |spec|
     bin/aws_lambda_ric
   ] + Dir['lib/**/*']
 
-  spec.bindir        = 'bin'
+  spec.bindir                = 'bin'
   # all application-style files are expected to be found in bindir
-  spec.executables   = 'aws_lambda_ric'
-  spec.require_paths = ['lib']
+  spec.executables           = 'aws_lambda_ric'
+  spec.require_paths         = ['lib']
 
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
These attributes are currently missing from the gemspec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
