### PR TITLE
Include GitHub action on push and pr

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -1,0 +1,20 @@
+name: test-on-push-and-pr
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Run 'pr' target
+      run: make pr

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ test-integ: setup-codebuild-agent
 build:
 	rake build
 
+.PHONY: pr
+pr: init test-unit test-smoke
+
 define HELP_MESSAGE
 
 Usage: $ make [TARGETS]
@@ -39,5 +42,6 @@ TARGETS
 	test-integ   Run Integration tests.
 	test-unit    Run Unit Tests.
 	test-smoke   Run Sanity/Smoke tests.
+	pr           Perform all checks before submitting a Pull Request.
 
 endef

--- a/aws_lambda_ric.gemspec
+++ b/aws_lambda_ric.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'activesupport', '~> 6.0.1'
 end

--- a/test/integration/codebuild-local/codebuild_build.sh
+++ b/test/integration/codebuild-local/codebuild_build.sh
@@ -95,7 +95,7 @@ then
     exit 1
 fi
 
-docker_command="docker run -it "
+docker_command="docker run "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "

--- a/test/unit/resources/runtime_handlers/Gemfile
+++ b/test/unit/resources/runtime_handlers/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'activesupport', '~> 6.0.1'


### PR DESCRIPTION
*Description of changes:*
* Added GitHub workflow to run the required checks on push and pr
* Added `pr` target in `Makefile` that would run the required checks before submitting a Pull Request
* Moved test dependency to `gemspec` file
* Removed unnecessary `-it` option from `codebuild_build.sh` because it was causing `tty` error when running the GitHub action.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
