### PR TITLE
Logger fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,32 @@
 PATH
   remote: .
   specs:
-    aws_lambda_ric (1.0.0)
+    aws_lambda_ric (1.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    concurrent-ruby (1.1.7)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
     minitest (5.14.2)
     rake (13.0.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 6.0.1)
   aws_lambda_ric!
   bundler (>= 2.0)
   minitest (~> 5.0)

--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -1,0 +1,21 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+module LoggerPatch
+  def initialize(logdev, shift_age = 0, shift_size = 1048576, level: 'debug',
+                 progname: nil, formatter: nil, datetime_format: nil,
+                 binmode: false, shift_period_suffix: '%Y%m%d')
+    #  use unpatched constructor if logdev is a filename or an IO Object other than $stdout or $stderr
+    if logdev && logdev != $stdout && logdev != $stderr
+      super(logdev, shift_age, shift_size, level: level, progname: progname,
+                      formatter: formatter, datetime_format: datetime_format,
+                      binmode: binmode, shift_period_suffix: shift_period_suffix)
+    else
+      self.level = level
+      self.progname = progname
+      @default_formatter = LambdaLogFormatter.new
+      self.datetime_format = datetime_format
+      self.formatter = formatter
+      @logdev = AwsLambdaRuntimeInterfaceClient::TelemetryLoggingHelper.telemetry_log_sink
+    end
+  end
+end

--- a/test/unit/harness-suite.json
+++ b/test/unit/harness-suite.json
@@ -206,6 +206,23 @@
         }
     },
     {
+      "name": "test_logger_logs_to_a_file_when_logdev_is_a_file",
+      "handler": "log.log_to_file_and_read_back",
+      "environmentVariables": {
+        "_LAMBDA_TELEMETRY_LOG_FD": "test/unit/resources/fd/test_fd"
+      },
+      "request": {
+        "messages": ["Single frame written to a file\n even if there are multiple lines\nthird line"],
+        "fd_path": "test/unit/resources/fd/test_fd",
+        "file_path": "test/unit/resources/fd/test_file.txt"
+      },
+      "assertion":
+        {
+          "transform": "I, \\[[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9]):[0-5][0-9]:[0-9]{2}.[0-9]{6} #[0-9]*\\]  INFO -- : Single frame written to a file\\\\n even if there are multiple lines\\\\nthird line",
+          "response": true
+        }
+    },
+    {
       "name": "test_logger_uses_telemetry_log_fd_when_logdev_is_stderr",
       "handler": "log.log_to_stderr_and_read_fd",
       "environmentVariables": {

--- a/test/unit/resources/runtime_handlers/log.rb
+++ b/test/unit/resources/runtime_handlers/log.rb
@@ -30,6 +30,17 @@ def log_to_stderr_and_read_fd(event:, context:)
   read_fd('', event)
 end
 
+def log_to_file_and_read_back(event:, context:)
+  logger = Logger.new(event['file_path'])
+  event['messages'].each { |m| logger.info(m) }
+  read_file('', event)
+end
+
+def read_file(content, event)
+  File.foreach(event['file_path']) { |line| content << line }
+  content
+end
+
 def read_fd(content, event)
   File.open(event['fd_path'], 'rb') do |file|
     until file.eof?


### PR DESCRIPTION
*Issue #, if available:* #7

*Description of changes:*

The Logger class is being monkey patched to use the telemetry logger when logging to `stdout` and/or `stderr`. There is a fallback to use the original logger when the `logdev` is not any of these targets (i.e. when it is a file name or IO object) but this fallback is not setting the names of the named parameters to the `initialize` call so it fails with error message:

```
"errorMessage": "wrong number of arguments (given 9, expected 1..3)",
```

Just adding the names to the named parameters fails with the error message `stack level too deep` which would indicate that the method is already being patched using `Module#prepend`. Using `method_alias` and `Module#prepend` on a method [causes](https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/) a conflict and eventually a stack overflow.

To be able to use prepend, I extracted the logger_patch to a separate module and then apply it with prepend.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
