### PR TITLE
Remove the Gemfile.lock from the gem files

### DIFF
--- a/aws_lambda_ric.gemspec
+++ b/aws_lambda_ric.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
     README.md
     Gemfile
     NOTICE
-    Gemfile.lock
     aws_lambda_ric.gemspec
     bin/aws_lambda_ric
   ] + Dir['lib/**/*']


### PR DESCRIPTION
*Description of changes:*

The Gemfile.lock was removed in #11 but it was missed to be removed from the files being included in the released gem. This is breaking our integration tests and it is still attempting to publish the removed file as part of the gem.

`make pr` did not fail as it runs `bundler init` before running the unit and smoke tests.

On a clean branch, running `make integ-tests` reproduces the failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
