### PR TITLE
Add "require 'stringio'"

### DIFF
--- a/lib/aws_lambda_ric/aws_lambda_marshaller.rb
+++ b/lib/aws_lambda_ric/aws_lambda_marshaller.rb
@@ -2,6 +2,8 @@
 
 # frozen_string_literal: true
 
+require 'stringio'
+
 module AwsLambda
   class Marshaller
     class << self

--- a/test/unit/resources/runtime_handlers/core.rb
+++ b/test/unit/resources/runtime_handlers/core.rb
@@ -1,5 +1,7 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+require 'stringio'
+
 def ping(event:, context:)
   resp = {}
   if event.nil?


### PR DESCRIPTION
StringIO needs a "require" to guarantee it's loaded.

See also https://github.com/aws/aws-lambda-ruby-runtime-interface-client/issues/14#issuecomment-1134670717

-------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
