### PR TITLE
CentOS 8 is EOL, stop testing on centOS 8

### DIFF
--- a/test/integration/codebuild/buildspec.os.centos.yml
+++ b/test/integration/codebuild/buildspec.os.centos.yml
@@ -16,7 +16,6 @@ batch:
         variables:
           DISTRO_VERSION:
             - "7"
-            - "8"
           RUNTIME_VERSION:
             - "2.7"
             - "2.6"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CentOS 8 is EOL due to which integration tests running on this flavour are failing to find the upstream mirrors for AppStream. 

Errors:
```
CentOS Linux 8 - AppStream                      125  B/s \|  38  B     00:00
--
97 | Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist

```
Cleaned up the buildspec to not run integration tests on CentOS 8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
