### PR TITLE
Update rbenv & ruby-build github URLs

### DIFF
--- a/test/integration/docker/Dockerfile.echo.amazonlinux
+++ b/test/integration/docker/Dockerfile.echo.amazonlinux
@@ -10,10 +10,10 @@ RUN yum update -y && \
     yum install -y git-core zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel
 
 RUN rm -rf /root/.rbenv/
-RUN git clone git://github.com/sstephenson/rbenv.git /root/.rbenv
+RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
 ENV PATH="/root/.rbenv/bin:$PATH"
 RUN echo 'eval "$(rbenv init -)"' >> /root/.bashrc
-RUN git clone git://github.com/sstephenson/ruby-build.git /root/.rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
 RUN source /root/.bashrc
 RUN RUNTIME_VERSIONS=($(rbenv install -L | grep  -oE $(echo "^${RUNTIME_VERSION}\.[0-9]+"))) && \
     RUNTIME_LATEST_VERSION=${RUNTIME_VERSIONS[-1]} && \

--- a/test/integration/docker/Dockerfile.echo.centos
+++ b/test/integration/docker/Dockerfile.echo.centos
@@ -10,10 +10,10 @@ RUN yum update -y && \
     yum install -y git-core zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel
 
 RUN rm -rf /root/.rbenv/
-RUN git clone git://github.com/sstephenson/rbenv.git /root/.rbenv
+RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
 ENV PATH="/root/.rbenv/bin:$PATH"
 RUN echo 'eval "$(rbenv init -)"' >> /root/.bashrc
-RUN git clone git://github.com/sstephenson/ruby-build.git /root/.rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
 RUN source /root/.bashrc
 RUN RUNTIME_VERSIONS=($(rbenv install -L | grep  -oE $(echo "^${RUNTIME_VERSION}\.[0-9]+"))) && \
     RUNTIME_LATEST_VERSION=${RUNTIME_VERSIONS[-1]} && \

--- a/test/integration/docker/Dockerfile.echo.ubuntu
+++ b/test/integration/docker/Dockerfile.echo.ubuntu
@@ -13,10 +13,10 @@ RUN apt-get update -y && \
 
 RUN ln -sf /bin/bash /bin/sh
 RUN rm -rf /root/.rbenv/
-RUN git clone git://github.com/sstephenson/rbenv.git /root/.rbenv
+RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
 ENV PATH="/root/.rbenv/bin:$PATH"
 RUN echo 'eval "$(rbenv init -)"' >> /root/.bashrc
-RUN git clone git://github.com/sstephenson/ruby-build.git /root/.rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build
 RUN bash /root/.bashrc
 
 RUN RUNTIME_VERSIONS=($(rbenv install -L | grep  -oE $(echo "^${RUNTIME_VERSION}\.[0-9]+"))) && \


### PR DESCRIPTION
*Issue #, if available:*
OS compatibility tests were failing with below error:

```
Step 8/35 : RUN git clone git://github.com/sstephenson/rbenv.git /root/.rbenv
--
1086 | ---> Running in 43e8b569eb85
1087 | Cloning into '/root/.rbenv'...
1088 | fatal: unable to connect to github.com:
1089 | github.com[0: 140.82.121.4]: errno=Connection timed out
```
*Description of changes:*
Updated the `rbenv` and `ruby-build` github URLs to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
