### PR TITLE
Stage 2.0.1 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can include this package in your preferred base image to make that base imag
 
 ## Requirements
 The Ruby Runtime Interface Client package currently supports Ruby versions:
- - 2.7.x up to and including 3.2.x
+ - 2.7.x
  
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can include this package in your preferred base image to make that base imag
 
 ## Requirements
 The Ruby Runtime Interface Client package currently supports Ruby versions:
- - 2.5.x up to and including 2.7.x
+ - 2.7.x up to and including 3.2.x
  
 ## Usage
 

--- a/aws_lambda_ric.gemspec
+++ b/aws_lambda_ric.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage              = 'https://github.com/aws/aws-lambda-ruby-runtime-interface-client'
 
   spec.license               = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 
   # Specify which files should be added to the gem when it is released.
   spec.files                 = %w[

--- a/lib/aws_lambda_ric/version.rb
+++ b/lib/aws_lambda_ric/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 module AwsLambdaRuntimeInterfaceClient
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
_Issue #, if available:_
Fixes #26 
_Description of changes:_
- Bump version
- Update `README.md`
- Drop support for Ruby2.5 as it is deprecated.

_Target (OCI, Managed Runtime, both):_
Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
