### PR TITLE
Add missing level_override instance variable to logger #initialize

### DIFF
--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -9,6 +9,7 @@ module LoggerPatch
     if !logdev || logdev == $stdout || logdev == $stderr
       logdev_lambda_overwrite = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
       @default_formatter = LogFormatter.new
+      @level_override = {}
     end
 
     super(logdev_lambda_overwrite, shift_age, shift_size, level: level, progname: progname,


### PR DESCRIPTION
_Issue #, if available:_ -

_Description of changes:_ This is needed for correct logging. Succeeds [this PR](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/32/files).

_Target (OCI, Managed Runtime, both):_ Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
