### PR TITLE
Fix Formatting override being ignored.

### DIFF
--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -9,6 +9,7 @@ module LoggerPatch
     if !logdev || logdev == $stdout || logdev == $stderr
       logdev_lambda_overwrite = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
       @default_formatter = LogFormatter.new
+      @level_override = {}
     end
 
     super(logdev_lambda_overwrite, shift_age, shift_size, level: level, progname: progname,

--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -4,16 +4,16 @@ module LoggerPatch
   def initialize(logdev, shift_age = 0, shift_size = 1048576, level: 'debug',
                  progname: nil, formatter: nil, datetime_format: nil,
                  binmode: false, shift_period_suffix: '%Y%m%d')
-    logdev_lambda_overwrite = logdev
+    logdev_lambda_override = logdev
+    formatter_override = formatter
     # use unpatched constructor if logdev is a filename or an IO Object other than $stdout or $stderr
     if !logdev || logdev == $stdout || logdev == $stderr
-      logdev_lambda_overwrite = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
-      @default_formatter = LogFormatter.new
-      @level_override = {}
+      logdev_lambda_override = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
+      formatter_override = LogFormatter.new
     end
 
-    super(logdev_lambda_overwrite, shift_age, shift_size, level: level, progname: progname,
-                                    formatter: formatter, datetime_format: datetime_format,
+    super(logdev_lambda_override, shift_age, shift_size, level: level, progname: progname,
+                                    formatter: formatter_override, datetime_format: datetime_format,
                                     binmode: binmode, shift_period_suffix: shift_period_suffix)
   end
 end


### PR DESCRIPTION
_Issue #, if available:_ usage of `LogFormatter.new` as the formatter was being ignored when using `AwsLambdaRIC::TelemetryLogger.telemetry_log_sink`.

_Description of changes:_ usage of `LogFormatter.new` as the formatter was being ignored when using `AwsLambdaRIC::TelemetryLogger.telemetry_log_sink`.

_Target (OCI, Managed Runtime, both):_ Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
