### PR TITLE
Don't Ignore Custom Formatters + Version Bump to 3.1.2

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### Jun 6, 2025
+`3.1.2`
+- Don't Ignore Custom Formatters. ([#48](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/48))
+
 ### Jun 5, 2025
 `3.1.1`
 - Fix Logger Formatting override being ignored. ([#47](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/47))

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Jun 6, 2025
 `3.1.2`
-- Don't Ignore Custom Formatters. ([#48](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/48))
+- Don't Ignore Custom Formatters. ([#49](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/49))
 
 ### Jun 5, 2025
 `3.1.1`

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,4 +1,8 @@
 ### May 21, 2025
+`3.1.1`
+- Fix Logger Formatting override being ignored. ([#47](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/47))
+
+### May 21, 2025
 `3.1.0`
 - Add support for multi tenancy ([#43](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/43))
 

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,4 +1,4 @@
-### May 21, 2025
+### Jun 5, 2025
 `3.1.1`
 - Fix Logger Formatting override being ignored. ([#47](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/47))
 

--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -9,7 +9,7 @@ module LoggerPatch
     # use unpatched constructor if logdev is a filename or an IO Object other than $stdout or $stderr
     if !logdev || logdev == $stdout || logdev == $stderr
       logdev_lambda_override = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
-      formatter_override = LogFormatter.new
+      formatter_override = formatter_override || LogFormatter.new
     end
 
     super(logdev_lambda_override, shift_age, shift_size, level: level, progname: progname,

--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -9,6 +9,7 @@ module LoggerPatch
     if !logdev || logdev == $stdout || logdev == $stderr
       logdev_lambda_overwrite = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
       @default_formatter = LogFormatter.new
+      @level_override = {}
     end
 
     super(logdev_lambda_overwrite, shift_age, shift_size, level: level, progname: progname,

--- a/lib/aws_lambda_ric/logger_patch.rb
+++ b/lib/aws_lambda_ric/logger_patch.rb
@@ -4,16 +4,16 @@ module LoggerPatch
   def initialize(logdev, shift_age = 0, shift_size = 1048576, level: 'debug',
                  progname: nil, formatter: nil, datetime_format: nil,
                  binmode: false, shift_period_suffix: '%Y%m%d')
-    logdev_lambda_overwrite = logdev
+    logdev_lambda_override = logdev
+    formatter_override = formatter
     # use unpatched constructor if logdev is a filename or an IO Object other than $stdout or $stderr
     if !logdev || logdev == $stdout || logdev == $stderr
-      logdev_lambda_overwrite = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
-      @default_formatter = LogFormatter.new
-      @level_override = {}
+      logdev_lambda_override = AwsLambdaRIC::TelemetryLogger.telemetry_log_sink
+      formatter_override = LogFormatter.new
     end
 
-    super(logdev_lambda_overwrite, shift_age, shift_size, level: level, progname: progname,
-                                    formatter: formatter, datetime_format: datetime_format,
+    super(logdev_lambda_override, shift_age, shift_size, level: level, progname: progname,
+                                    formatter: formatter_override, datetime_format: datetime_format,
                                     binmode: binmode, shift_period_suffix: shift_period_suffix)
   end
 end

--- a/lib/aws_lambda_ric/version.rb
+++ b/lib/aws_lambda_ric/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwsLambdaRIC
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/lib/aws_lambda_ric/version.rb
+++ b/lib/aws_lambda_ric/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwsLambdaRIC
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
_Description of changes:_  

We have 2 PRs modifying the logging behavior
https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/32
https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/47

Following the first PR, in case the `logdevice` was `stdout` or  `stderr`, lambda's custom formatter which we used to assign to `@default_formatter` was ignored since we were calling the constructor which restored the  `@default_formatter` to ruby's built in default formatter; **HOWEVER, if you passed in a formatter, that will be used.**

Following the second PR, in case the `logdevice` was `stdout` or  `stderr`, the formatter is always set to be lambda's custom formatter.

This PR allows custom formatters.

_Target (OCI, Managed Runtime, both):_ Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
