### PR TITLE
Handle Signal Exceptions during Runtime API Http Requests Gracefully and Version Bump to 3.1.3

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### Jun 10, 2025
+`3.1.3`
+- Handle Interrupts to the Runtime API Http Requests Gracefully and Version Bump to 3.1.3. ([#50](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/50))
+
 ### Jun 6, 2025
 `3.1.2`
 - Don't Ignore Custom Formatters. ([#49](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/49))

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Jun 10, 2025
 `3.1.3`
-- Handle Interrupts to the Runtime API Http Requests Gracefully and Version Bump to 3.1.3. ([#50](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/50))
+- Handle Signal Exceptions during Runtime API Http Requests Gracefully and Version Bump to 3.1.3 ([#50](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/50))
 
 ### Jun 6, 2025
 `3.1.2`

--- a/lib/aws_lambda_ric/lambda_server.rb
+++ b/lib/aws_lambda_ric/lambda_server.rb
@@ -33,8 +33,8 @@ class RapidClient
           "Received #{resp.code} when waiting for next invocation."
         )
       end
-    rescue Interrupt
-      puts "Next invocation HTTP request from the runtime interface client was interrupted, gracefully shutting down."
+    rescue SignalException => sig
+      puts "Next invocation HTTP request from the runtime interface client was interrupted with a #{sig} SIGNAL, gracefully shutting down."
       exit 0
     rescue LambdaErrors::InvocationError => e
       raise e

--- a/lib/aws_lambda_ric/lambda_server.rb
+++ b/lib/aws_lambda_ric/lambda_server.rb
@@ -33,6 +33,9 @@ class RapidClient
           "Received #{resp.code} when waiting for next invocation."
         )
       end
+    rescue Interrupt
+      puts "Next invocation HTTP request from the runtime interface client was interrupted, gracefully shutting down."
+      exit 0
     rescue LambdaErrors::InvocationError => e
       raise e
     rescue StandardError => e

--- a/lib/aws_lambda_ric/lambda_server.rb
+++ b/lib/aws_lambda_ric/lambda_server.rb
@@ -34,8 +34,7 @@ class RapidClient
         )
       end
     rescue SignalException => sig
-      puts "Next invocation HTTP request from the runtime interface client was interrupted with a #{sig} SIGNAL, gracefully shutting down."
-      exit 0
+      raise LambdaErrors::InvocationError.new("Next invocation HTTP request from the runtime interface client was interrupted with a #{sig} SIGNAL, gracefully shutting down.")
     rescue LambdaErrors::InvocationError => e
       raise e
     rescue StandardError => e

--- a/lib/aws_lambda_ric/version.rb
+++ b/lib/aws_lambda_ric/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwsLambdaRIC
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end


### PR DESCRIPTION
Handle Signal Exceptions during Runtime API Http Requests Gracefully and Version Bump to 3.1.3

_Issue #, if available:_ https://github.com/aws/aws-lambda-ruby-runtime-interface-client/issues/28

_Description of changes:_ Handle the Ruby HTTP library SignalExceptions when receiving SIGTERM/SIGKILL/Interrupt/etc... and shutdown gracefully without polluting customer logs with a false positive exception log.

_Target (OCI, Managed Runtime, both):_ Managed Runtimes (When using Extensions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
