### PR TITLE
Fix undefined variable in test error message

### DIFF
--- a/test/integration/codebuild/buildspec.os.alpine.1.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.1.yml
@@ -87,7 +87,7 @@ phases:
       - |
         echo "Response: ${actual}"
         if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "fail! runtime: ${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION} - expected output $expected - got $actual"
           exit -1
         fi
     finally:

--- a/test/integration/codebuild/buildspec.os.alpine.2.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.2.yml
@@ -87,7 +87,7 @@ phases:
       - |
         echo "Response: ${actual}"
         if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "fail! runtime: ${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION} - expected output $expected - got $actual"
           exit -1
         fi
     finally:

--- a/test/integration/codebuild/buildspec.os.amazonlinux.yml
+++ b/test/integration/codebuild/buildspec.os.amazonlinux.yml
@@ -84,7 +84,7 @@ phases:
       - |
         echo "Response: ${actual}"
         if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "fail! runtime: ${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION} - expected output $expected - got $actual"
           exit -1
         fi
     finally:

--- a/test/integration/codebuild/buildspec.os.debian.yml
+++ b/test/integration/codebuild/buildspec.os.debian.yml
@@ -85,7 +85,7 @@ phases:
       - |
         echo "Response: ${actual}"
         if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "fail! runtime: ${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION} - expected output $expected - got $actual"
           exit -1
         fi
     finally:

--- a/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -87,7 +87,7 @@ phases:
       - |
         echo "Response: ${actual}"
         if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "fail! runtime: ${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION} - expected output $expected - got $actual"
           exit -1
         fi
     finally:


### PR DESCRIPTION
_Issue #, if available:_
**Issue**: Error messages used undefined `$RUNTIME` variable, showing blank runtime info on test failures

_Description of changes:_

**Summary**
This PR fixes a bug in integration test error reporting across all OS distributions.

**Bug Fix**
- **Fixed undefined `$RUNTIME` variable** in all integration test buildspec files
 - **Fix**: Changed `$RUNTIME` to `${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}` 

_Target (OCI, Managed Runtime, both):_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
