### PR TITLE
Add logger runtime dependency for Ruby 3.5 compatibility

### DIFF
--- a/aws_lambda_ric.gemspec
+++ b/aws_lambda_ric.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables           = 'aws_lambda_ric'
   spec.require_paths         = ['lib']
 
+  spec.add_runtime_dependency "logger", ">= 1.4", "< 2.0"
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
_Issue #, if available:_ 51

_Description of changes:_
Added `logger` as a runtime dependency to fix Ruby 3.5 compatibility. The gem uses require `'logger'` in multiple files but doesn't declare it as a dependency. In Ruby 3.5, logger will move from default gems to bundled gems, requiring explicit declaration to prevent load errors.

_Target (OCI, Managed Runtime, both):_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
