### PR TITLE
Update README with correct handler usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The Ruby Runtime Interface Client package currently supports ruby 3.0 and above.
 
 ## Migration from 2.x to 3.x
 
-**Change**: Version 3.0.0 introduced a change in how the handler is specified:
+**Important**: Version 2.x is deprecated. Please upgrade to version 3.x. For more information about Lambda runtime support, see the [AWS Lambda runtimes documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+
+**Breaking Change**: Version 3.0.0 introduced a change in how the handler is specified:
 
 - **Version 2.x**: Handler was passed as a command line argument
 - **Version 3.x+**: Handler must be specified via the `_HANDLER` environment variable


### PR DESCRIPTION
_Issue #, if available:_ #42

_Description of changes:_
Updated README to document correctly the handler usage:
- Remove the misleading CMD line from the Dockerfile example
- Explicitly document that _HANDLER must be set via environment variable

_Target (OCI, Managed Runtime, both):_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
