### PR TITLE
bump version to 3.2.0

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,15 @@
+### Apr 15, 2026
+`3.2.0`
+- fix: sha GitHub actions ([#59](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/59))
+- Add structured JSON logging support 
+ ([#58](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/58))
+- feat: add dockerized testing
+ ([#57](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/57))
+- Update README with correct handler usage ([#55](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/55))
+- Implement local RIC running ([#54](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/54))
+- Add logger runtime dependency for Ruby 3.5 compatibility ([#53](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/53))
+- Fix undefined variable in test error message ([#52](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/52))
+
 ### Jun 10, 2025
 `3.1.3`
 - Handle Signal Exceptions during Runtime API Http Requests Gracefully and Version Bump to 3.1.3 ([#50](https://github.com/aws/aws-lambda-ruby-runtime-interface-client/pull/50))

--- a/lib/aws_lambda_ric/version.rb
+++ b/lib/aws_lambda_ric/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwsLambdaRIC
-  VERSION = '3.1.3'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ 
Added Structured logging support and add dockerized testing with some other fix as well.

As it is a big change, version Bump to `3.2.0` instead of `3.1.4`

_Target (OCI, Managed Runtime, both):_ Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
